### PR TITLE
Change subfigure.sty to subcaption.sty in houkoku.sty

### DIFF
--- a/latex/houkoku/houkoku.sty
+++ b/latex/houkoku/houkoku.sty
@@ -4,7 +4,7 @@
 \usepackage{listings}
 \usepackage{siunitx}
 
-\usepackage{subfigure}
+\usepackage[subrefformat=parens]{subcaption}
 \usepackage{url}
 \usepackage{multirow}
 


### PR DESCRIPTION
subfigure is so old that it is not updated recently.
We should use \subcaption and \minipage instead of \subfigure.
http://ichiro-maruta.blogspot.jp/2013/03/latex.html

How to use subcaption（http://www.yamamo10.jp/~yamamoto/comp/latex/make_doc/insert_fig/index.php#SUBCAP）