### PR TITLE
Change subfigure.sty to subcaption.sty

### DIFF
--- a/latex/happyou/happyou.sty
+++ b/latex/happyou/happyou.sty
@@ -3,7 +3,7 @@
 \usepackage[dvipdfmx]{graphicx}
 \usepackage{listings}
 
-\usepackage{subfigure}
+\usepackage[subrefformat=parens]{subcaption}
 \usepackage{url}
 \usepackage{multirow}
 


### PR DESCRIPTION
\subfigure is so old that it is not updated recently.
We should use \subcaption and \minipage instead of \subfigure.